### PR TITLE
Cluster quarantine partition w/ network partition

### DIFF
--- a/SocketLeakDetection.sln
+++ b/SocketLeakDetection.sln
@@ -11,7 +11,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SocketLeakDetection.Simple.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{1DBA19CE-CAD3-4AC3-91F8-FD434A524ACD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SocketLeakDetection.LiveLeak.Demo", "src\SocketLeakDetection.LiveLeak.Demo\SocketLeakDetection.LiveLeak.Demo.csproj", "{846131E6-A474-4967-8215-01C604184AF4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SocketLeakDetection.LiveLeak.Demo", "src\SocketLeakDetection.LiveLeak.Demo\SocketLeakDetection.LiveLeak.Demo.csproj", "{846131E6-A474-4967-8215-01C604184AF4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SocketLeakDetection.ClusterQuarantine.Demo", "src\SocketLeakDetection.ClusterQuarantine.Demo\SocketLeakDetection.ClusterQuarantine.Demo.csproj", "{44425404-884B-4A5B-A060-132704D225D0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -71,6 +73,18 @@ Global
 		{846131E6-A474-4967-8215-01C604184AF4}.Release|x64.Build.0 = Release|Any CPU
 		{846131E6-A474-4967-8215-01C604184AF4}.Release|x86.ActiveCfg = Release|Any CPU
 		{846131E6-A474-4967-8215-01C604184AF4}.Release|x86.Build.0 = Release|Any CPU
+		{44425404-884B-4A5B-A060-132704D225D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{44425404-884B-4A5B-A060-132704D225D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{44425404-884B-4A5B-A060-132704D225D0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{44425404-884B-4A5B-A060-132704D225D0}.Debug|x64.Build.0 = Debug|Any CPU
+		{44425404-884B-4A5B-A060-132704D225D0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{44425404-884B-4A5B-A060-132704D225D0}.Debug|x86.Build.0 = Debug|Any CPU
+		{44425404-884B-4A5B-A060-132704D225D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{44425404-884B-4A5B-A060-132704D225D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{44425404-884B-4A5B-A060-132704D225D0}.Release|x64.ActiveCfg = Release|Any CPU
+		{44425404-884B-4A5B-A060-132704D225D0}.Release|x64.Build.0 = Release|Any CPU
+		{44425404-884B-4A5B-A060-132704D225D0}.Release|x86.ActiveCfg = Release|Any CPU
+		{44425404-884B-4A5B-A060-132704D225D0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -78,6 +92,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{97C4CCAF-72FB-43EF-A4DF-8BB5951E2985} = {1DBA19CE-CAD3-4AC3-91F8-FD434A524ACD}
 		{846131E6-A474-4967-8215-01C604184AF4} = {1DBA19CE-CAD3-4AC3-91F8-FD434A524ACD}
+		{44425404-884B-4A5B-A060-132704D225D0} = {1DBA19CE-CAD3-4AC3-91F8-FD434A524ACD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7463B3C5-BC50-4032-ADDD-C2F2632D58FF}

--- a/src/SocketLeakDetection.ClusterQuarantine.Demo/Program.cs
+++ b/src/SocketLeakDetection.ClusterQuarantine.Demo/Program.cs
@@ -109,6 +109,10 @@ namespace SocketLeakDetection.ClusterQuarantine.Demo
             Console.ReadLine();
             RarpFor(seed).Quarantine(node2Addr, uid);
 
+            await Task.Delay(TimeSpan.FromSeconds(2.5));
+            seed.ActorSelection(new RootActorPath(node2Addr) / "user" / "silence").Tell("fuber");
+
+
             Console.WriteLine("Press enter to terminate quarantined node");
             Console.ReadLine();
             await quarantineNode.Terminate();

--- a/src/SocketLeakDetection.ClusterQuarantine.Demo/Program.cs
+++ b/src/SocketLeakDetection.ClusterQuarantine.Demo/Program.cs
@@ -106,17 +106,17 @@ namespace SocketLeakDetection.ClusterQuarantine.Demo
             }
             seed.Log.Info("Cluster up.");
 
-            Console.WriteLine("Press enter to begin quarantine.");
-            Console.ReadLine();
+            //Console.WriteLine("Press enter to begin quarantine.");
+            //Console.ReadLine();
             RarpFor(seed).Quarantine(node2Addr, uid);
 
             await Task.Delay(TimeSpan.FromSeconds(2.5));
             seed.ActorSelection(new RootActorPath(node2Addr) / "user" / "silence").Tell("fuber");
 
 
-            Console.WriteLine("Press enter to terminate quarantined node");
-            Console.ReadLine();
-            await quarantineNode.Terminate();
+            //Console.WriteLine("Press enter to terminate quarantined node");
+            //Console.ReadLine();
+            //await quarantineNode.Terminate();
 
             seed.WhenTerminated.Wait();
         }

--- a/src/SocketLeakDetection.ClusterQuarantine.Demo/Program.cs
+++ b/src/SocketLeakDetection.ClusterQuarantine.Demo/Program.cs
@@ -1,7 +1,13 @@
 ﻿using System;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Cluster;
 using Akka.Configuration;
+using Akka.Remote;
 using Akka.Routing;
+using Akka.Util.Internal;
 
 namespace SocketLeakDetection.ClusterQuarantine.Demo
 {
@@ -34,6 +40,7 @@ namespace SocketLeakDetection.ClusterQuarantine.Demo
 			            }
 		            }
                 }
+                akka.cluster.seed-nodes = [""akka.tcp://quarantine-test@127.0.0.1:9444""]
             ";
         }
 
@@ -47,9 +54,36 @@ namespace SocketLeakDetection.ClusterQuarantine.Demo
             return node;
         }
 
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
-            
+            // launch seed node
+            var seed = StartNode(9444);
+            var leakDetector = seed.ActorOf(Props.Create(() => new TcpPortUseSupervisor(new[]{ IPAddress.Loopback })), "portMonitor");
+
+            // start node that will be quarantined
+            var quarantineNode = StartNode(9555);
+            var node2Addr = Cluster.Get(quarantineNode).SelfAddress;
+            var uid = AddressUidExtension.Uid(quarantineNode);
+
+            //var peanutGallery = Enumerable.Repeat(1, 3).Select(x => StartNode(0)).ToList();
+
+            Func<int, bool> checkMembers = i => Cluster.Get(seed).State.Members.Count == i;
+
+            seed.Log.Info("Waiting for members to join...");
+            while (!checkMembers(2))
+            {
+                await Task.Delay(TimeSpan.FromSeconds(2));
+            }
+            seed.Log.Info("Cluster up.");
+
+            RarpFor(seed).Quarantine(node2Addr, uid);
+
+            seed.WhenTerminated.Wait();
+        }
+
+        static RemoteActorRefProvider RarpFor(ActorSystem system)
+        {
+            return system.AsInstanceOf<ExtendedActorSystem>().Provider.AsInstanceOf<RemoteActorRefProvider>();
         }
     }
 }

--- a/src/SocketLeakDetection.ClusterQuarantine.Demo/Program.cs
+++ b/src/SocketLeakDetection.ClusterQuarantine.Demo/Program.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Routing;
+
+namespace SocketLeakDetection.ClusterQuarantine.Demo
+{
+    public class SilenceActor : ReceiveActor
+    {
+        public SilenceActor()
+        {
+            ReceiveAny(o =>
+            {
+
+            });
+        }
+    }
+
+    class Program
+    {
+        private static Config ClusterConfig(int portNumber)
+        {
+            return @"
+                akka.actor.provider = cluster
+                akka.remote.dot-netty.tcp.port = """+ portNumber + @"""
+                akka.remote.dot-netty.tcp.hostname = 127.0.0.1
+                akka.actor.deployment{
+                    /random {
+			            router = random-group
+			            routees.paths = [""/user/silence""]
+			            cluster{
+				            enabled = on
+				            allow-local-routees = off
+			            }
+		            }
+                }
+            ";
+        }
+
+        public static ActorSystem StartNode(int portNumber)
+        {
+            var node = ActorSystem.Create("quarantine-test", ClusterConfig(portNumber));
+            var silence = node.ActorOf(Props.Create(() => new SilenceActor()), "silence");
+            var router = node.ActorOf(Props.Empty.WithRouter(FromConfig.Instance), "random");
+            node.Scheduler.ScheduleTellRepeatedly(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2), router, "hit", ActorRefs.NoSender);
+
+            return node;
+        }
+
+        static void Main(string[] args)
+        {
+            
+        }
+    }
+}

--- a/src/SocketLeakDetection.ClusterQuarantine.Demo/Program.cs
+++ b/src/SocketLeakDetection.ClusterQuarantine.Demo/Program.cs
@@ -56,6 +56,7 @@ namespace SocketLeakDetection.ClusterQuarantine.Demo
                 akka.actor.provider = cluster
                 akka.remote.dot-netty.tcp.port = """+ portNumber + @"""
                 akka.remote.dot-netty.tcp.hostname = 127.0.0.1
+                akka.remote.dot-netty.tcp.applied-adapters = [""gremlin""] # enables packet loss control
                 akka.actor.deployment{
                     /random {
 			            router = random-group
@@ -66,7 +67,7 @@ namespace SocketLeakDetection.ClusterQuarantine.Demo
 			            }
 		            }
                 }
-                akka.cluster.seed-nodes = [""akka.tcp://quarantine-test@127.0.0.1:9444""]
+                akka.cluster.seed-nodes = [""akka.gremlin.tcp://quarantine-test@127.0.0.1:9444""]
             ";
         }
 

--- a/src/SocketLeakDetection.ClusterQuarantine.Demo/Program.cs
+++ b/src/SocketLeakDetection.ClusterQuarantine.Demo/Program.cs
@@ -87,7 +87,8 @@ namespace SocketLeakDetection.ClusterQuarantine.Demo
             var pbm = PetabridgeCmd.Get(seed);
             pbm.RegisterCommandPalette(ClusterCommands.Instance);
             pbm.Start();
-            var leakDetector = seed.ActorOf(Props.Create(() => new TcpPortUseSupervisor(new[]{ IPAddress.Loopback })), "portMonitor");
+            var settings = new SocketLeakDetectorSettings(maxPorts:20000);
+            var leakDetector = seed.ActorOf(Props.Create(() => new TcpPortUseSupervisor(settings, new[]{ IPAddress.Loopback })), "portMonitor");
 
             // start node that will be quarantined
             var quarantineNode = StartNode(9555);

--- a/src/SocketLeakDetection.ClusterQuarantine.Demo/SocketLeakDetection.ClusterQuarantine.Demo.csproj
+++ b/src/SocketLeakDetection.ClusterQuarantine.Demo/SocketLeakDetection.ClusterQuarantine.Demo.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Akka.Cluster" Version="1.3.12" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SocketLeakDetection\SocketLeakDetection.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SocketLeakDetection.ClusterQuarantine.Demo/SocketLeakDetection.ClusterQuarantine.Demo.csproj
+++ b/src/SocketLeakDetection.ClusterQuarantine.Demo/SocketLeakDetection.ClusterQuarantine.Demo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/src/SocketLeakDetection.ClusterQuarantine.Demo/SocketLeakDetection.ClusterQuarantine.Demo.csproj
+++ b/src/SocketLeakDetection.ClusterQuarantine.Demo/SocketLeakDetection.ClusterQuarantine.Demo.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Akka.Cluster" Version="1.3.12" />
+    <PackageReference Include="Petabridge.Cmd.Cluster" Version="0.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SocketLeakDetection/SocketLeakDetectorActor.cs
+++ b/src/SocketLeakDetection/SocketLeakDetectorActor.cs
@@ -182,12 +182,12 @@ namespace SocketLeakDetection
             {
                 _leakDetector.Next(count.CurrentPortCount);
 
-                if (_log.IsDebugEnabled)
-                {
-                    _log.Debug("Received port count of {0} for interface {1}", count.CurrentPortCount,
+                //if (_log.IsDebugEnabled)
+                //{
+                    _log.Info("Received port count of {0} for interface {1}", count.CurrentPortCount,
                         count.HostInterface);
-                    _log.Debug("Danger threshold: {0} - Observed threshold: {1}", _leakDetector.MaxDifference, _leakDetector.RelativeDifference);
-                }
+                    _log.Info("Danger threshold: {0} - Observed threshold: {1}", _leakDetector.MaxDifference, _leakDetector.RelativeDifference);
+                //}
                     
 
                 if (_leakDetector.ShouldFail && _breachSignal == null)

--- a/src/SocketLeakDetection/TcpPortMonitoringActor.cs
+++ b/src/SocketLeakDetection/TcpPortMonitoringActor.cs
@@ -78,7 +78,7 @@ namespace SocketLeakDetection
             //}
 
             var portsPerAddress = ipProperties.GetActiveTcpConnections().GroupBy(x => x.LocalEndPoint.Address)
-                .Select(x => new TcpCount(x.Key, x.Count()));
+                .Select(x => new TcpCount(x.Key, x.Select(y => y.LocalEndPoint.Port).Distinct().Count()));
 
             foreach (var t in portsPerAddress)
                 _supervisor.Tell(t);


### PR DESCRIPTION
Going to use the `FailureTransportAdapter` built into Akka.Remote to inject a network partition at the time of quarantine and see if this has any impact on the socket count.